### PR TITLE
Attempt to fix bug in issue 9-ec-ids-empty

### DIFF
--- a/src/CLEAN/utils.py
+++ b/src/CLEAN/utils.py
@@ -172,12 +172,16 @@ def retrieve_esm2_embedding(fasta_name):
     subprocess.run(command)
 
 def merge_sequence_structure_emb(csv_file):
+    # get_ec_id_dict() actually returns tuple with 2 dicts
+    # _ would be Dict[any, any]
+    # ec_id_dict is Dict[any, set[any]]
     _, ec_id_dict = get_ec_id_dict(f'data/{csv_file}.csv')
-    for ec in ec_id_dict:
-        seq_emb = format_esm(torch.load(f'data/esm2_data/{ec}.pt'))
-        stru_emb = torch.load(f'data/resnet_data/{ec}.pt')
-        merged = torch.cat([seq_emb, stru_emb], dim=0)
-        torch.save(merged, f'data/esm_data/{ec}.pt')
+    for key, value in ec_id_dict.items():
+        for ec in value:
+            seq_emb = format_esm(torch.load(f'data/esm2_data/{ec}.pt'))
+            stru_emb = torch.load(f'data/resnet_data/{ec}.pt')
+            merged = torch.cat([seq_emb, stru_emb], dim=0)
+            torch.save(merged, f'data/esm_data/{ec}.pt')
  
 def compute_esm_distance(train_file):
     ensure_dirs()


### PR DESCRIPTION
Please test that this code creates the expected output! I've been staring at it too long and am questioning everything.

Previously the loop was iterating over empty values, so it was looking for blank embedding file names such as 'data/esm2_data/.pt'. The variable ec_id_dict is a dict with the values that are a set, which is what holds all the ids/names of the files. Now the code iterates through the values and thus can find the correct file names, such as something like 'data/esm2_data/A0A2S0XQA5.pt'.